### PR TITLE
fix(loader): resolve core.js URL against loader's own module URL (fixes #90)

### DIFF
--- a/packages/loader/build.js
+++ b/packages/loader/build.js
@@ -5,6 +5,7 @@ await esbuild.build({
   entryPoints: ['index.ts'],
   outfile: 'index.js',
   bundle: true,
+  format: 'esm',
   minify: true,
   define: {
     'process.env.CORE_NS': `"typora-plugin-core@v2"`,

--- a/packages/loader/index.ts
+++ b/packages/loader/index.ts
@@ -15,7 +15,7 @@ import { File, _options, bridge, reqnode } from 'typora'
 
   const pluginCore = env.PLUGIN_CORE_PATH
     ? env.PLUGIN_CORE_PATH.replace(/\{VAULT\}/, mountFolder)
-    : `./${loaderConfig.coreVersion}/core.js`
+    : new URL(`./${loaderConfig.coreVersion}/core.js`, import.meta.url).href
 
   // @ts-ignore
   window[Symbol.for(`${process.env.CORE_NS}:env`)] = {


### PR DESCRIPTION
## Summary

Fix a silent loader failure on macOS 15 + Typora 1.12.6 where the community plugin framework appears to be installed correctly but never actually loads — no `Community Plugins` pane in Preferences, no plugin instances, no error surfaced to the user.

Fixes #90.

## Root cause

`packages/loader/index.ts` builds its fallback core-import path as a bare relative specifier:

```ts
const pluginCore = env.PLUGIN_CORE_PATH
  ? env.PLUGIN_CORE_PATH.replace(/\{VAULT\}/, mountFolder)
  : `./${loaderConfig.coreVersion}/core.js`
```

When the installer injects the `<script type="module">` tag into Typora's bundled `index.html` via a `file://` URL, the browser resolves that relative specifier against the **document's base URL** (the `Typora.app` bundle dir) rather than the loader module's own URL. So `import()` ends up fetching something like:

```
file:///Applications/Typora.app/Contents/Resources/TypeMark/2.7.7/core.js   ← 404
```

instead of the actual file under user data. The promise rejects inside the IIFE and no error bubbles up to anything the user can see.

## Fix

Two small changes in `packages/loader/`:

1. **`index.ts`** — resolve the core.js URL against `import.meta.url` so it's always relative to the loader module itself, regardless of where the document is loaded from.

   ```diff
   -   : `./${loaderConfig.coreVersion}/core.js`
   +   : new URL(`./${loaderConfig.coreVersion}/core.js`, import.meta.url).href
   ```

2. **`build.js`** — set esbuild `format: 'esm'`. The injected `<script>` tag is already `type="module"`, but the loader was being bundled as `iife` (esbuild's default), which stubs `import.meta` to an empty object and emits a build-time warning:

   ```
   ▲ [WARNING] "import.meta" is not available with the "iife" output format and will be empty
   ```

   Switching to `esm` matches the actual script type, removes the warning, and keeps `import.meta.url` intact in the minified output.

## Verification

Tested on macOS 15.4.1 + Typora 1.12.6 (the combo reported in #90):

**Before the fix**, with `loader.json` debug flag on:

- `Object.getOwnPropertySymbols(window).find(s => s.toString() === 'Symbol(typora-plugin-core@v2)')` → `undefined`
- No `[Typora Plugin Loader] Start importing ...` log
- Manually running the loader body in DevTools reproduced: `Importing a module script failed` fetching `file:///Applications/Typora.app/Contents/Resources/TypeMark/2.7.7/core.js`

**After the fix**, on the exact same Typora install, same macOS:

- Framework symbol present
- Console shows `[Typora Plugin Loader] Start importing "file:///Users/<user>/Library/Application Support/abnerworks.Typora/plugins/2.7.7/core.js"`
- `app.plugins.manifests` enumerates discovered plugins correctly

## Scope

This is intentionally a single-concern change — loader only, no bundler/config cleanup elsewhere. Related issue #82 (`Yr.bundle.filePath is undefined` inside `core.js`) has a different root cause and isn't addressed here.

## Compatibility

- The `esm` output format only affects the loader package's build output (`packages/loader/index.js`). The installer-generated `<script>` tag is already `type="module"`, so ESM semantics were implicitly expected already.
- No API surface changes to `core.js` or plugin authors.
- No changes to `installer/` templates — the existing `type="module"` script tag is the correct one.
